### PR TITLE
Fixed money glitch.

### DIFF
--- a/client/items/atm/withdraw.sqf
+++ b/client/items/atm/withdraw.sqf
@@ -19,7 +19,7 @@ if (isNull _dialog) exitWith {};
 _input = _dialog displayCtrl AtmAmountInput_IDC;
 _amount = _input call mf_verify_money_input;
 
-if (_amount < 1) exitWith {};
+if (_amount < 100) exitWith {systemChat "Please enter more then 100 cash"};
 
 if (player getVariable ["bmoney", 0] < _amount) exitWith
 {


### PR DESCRIPTION
If you enter a number in the Withdraw window, for example a 2 or 1, you can generate money out of no where. Its a Money glitch, and should be fixed.