### PR TITLE
Makes glitching into objects harder when exiting a vehicle

### DIFF
--- a/server/functions/fn_vehicleGetInOutServer.sqf
+++ b/server/functions/fn_vehicleGetInOutServer.sqf
@@ -21,6 +21,27 @@ if (isPlayer _unit && owner _vehicle == owner _unit) then
 _vehicle setVariable ["vehSaving_hoursUnused", 0];
 _vehicle setVariable ["vehSaving_lastUse", diag_tickTime];
 
+//Don't allow players to glitch into objects when exiting vehicles
+if (isNull objectParent _unit) then 
+{
+	//Check the current position of the player
+	_pos = [_unit, 0, 0.25, 2, 0, 1, 0] call BIS_fnc_findSafePos;
+
+	//Function returns current position [x,y] if it is safe, otherwise map center
+	// is returned [x,y,z]. In the second case, the player current position is
+	// invalid and we find another within 5m of the vehicle
+	if(count _pos > 2) then {
+		//Find position relative to vehicle, 5m max
+		_pos = [_vehicle, 0, 5, 1, 0, 45, 0] call BIS_fnc_findSafePos;
+
+		//If a position is found, then move the unit to a non-glitched pos
+		if(count _pos == 2) then {
+			_unit setPos _pos;
+		};
+	};
+};
+
+
 {
 	if (isAgent teamMember _x) then
 	{

--- a/server/functions/fn_vehicleGetInOutServer.sqf
+++ b/server/functions/fn_vehicleGetInOutServer.sqf
@@ -26,7 +26,7 @@ _vehicle setVariable ["vehSaving_lastUse", diag_tickTime];
 if (isNull objectParent _unit) then 
 {
 	//Check the current position of the player
-	_pos = [_unit, 0, 0.25, 2, 0, 1, 0] call BIS_fnc_findSafePos;
+	_pos = [_unit, 0, 0.25, 0.5, 0, 1, 0] call BIS_fnc_findSafePos;
 
 	//Function returns current position [x,y] if it is safe, otherwise map center
 	// is returned [x,y,z]. In the second case, the player current position is

--- a/server/functions/fn_vehicleGetInOutServer.sqf
+++ b/server/functions/fn_vehicleGetInOutServer.sqf
@@ -5,6 +5,7 @@
 //	@file Author: AgentRev
 
 params ["_vehicle", "_seat", "_unit"];
+private ["_pos"];
 
 _unit setVariable ["lastVehicleRidden", netId _vehicle, true];
 


### PR DESCRIPTION
This code change checks the unit's current position after exiting the vehicle using BIS_fnc_findSafePos with a very small radius. If the position returned is default (map center x,y,z), then the code tries to find a safe position from the vehicle within 5m. If found, it moves the player unit to the new location.